### PR TITLE
Rename psaPatcher alias to psa-patcher

### DIFF
--- a/charts/patchwork/Chart.lock
+++ b/charts/patchwork/Chart.lock
@@ -5,5 +5,5 @@ dependencies:
 - name: psa-restricted-patcher
   repository: https://bryopsida.github.io/psa-restricted-patcher/
   version: 0.10.0
-digest: sha256:2d78700b07cd65fb043c739b9f89aa7572b252fdfd3f490feab45c25659c3b56
-generated: "2023-07-02T06:59:56.647998-05:00"
+digest: sha256:a15db5ce71df28e3d593db87d78908c80791f71038533d765db8cba78b772aeb
+generated: "2023-07-03T18:58:00.665815-05:00"

--- a/charts/patchwork/Chart.yaml
+++ b/charts/patchwork/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: patchwork
 description: Watches deployments, daemonsets, and statefulsets for image updates and will automatically trigger rollouts to pull in updates
 type: application
-version: 0.8.0
+version: 0.8.1
 appVersion: '0.4.0'
 dependencies:
   - name: redis
@@ -11,7 +11,7 @@ dependencies:
   - name: psa-restricted-patcher
     repository: https://bryopsida.github.io/psa-restricted-patcher/
     version: 0.10.0
-    condition: psaPatcher.enabled
-    alias: psaPatcher
+    condition: psa-patcher.enabled
+    alias: psa-patcher
 maintainers:
   - name: bryopsida

--- a/charts/patchwork/README.md
+++ b/charts/patchwork/README.md
@@ -1,6 +1,6 @@
 # patchwork
 
-![Version: 0.8.0](https://img.shields.io/badge/Version-0.8.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.4.0](https://img.shields.io/badge/AppVersion-0.4.0-informational?style=flat-square)
+![Version: 0.8.1](https://img.shields.io/badge/Version-0.8.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.4.0](https://img.shields.io/badge/AppVersion-0.4.0-informational?style=flat-square)
 
 Watches deployments, daemonsets, and statefulsets for image updates and will automatically trigger rollouts to pull in updates
 
@@ -14,7 +14,7 @@ Watches deployments, daemonsets, and statefulsets for image updates and will aut
 
 | Repository | Name | Version |
 |------------|------|---------|
-| https://bryopsida.github.io/psa-restricted-patcher/ | psaPatcher(psa-restricted-patcher) | 0.10.0 |
+| https://bryopsida.github.io/psa-restricted-patcher/ | psa-patcher(psa-restricted-patcher) | 0.10.0 |
 | https://groundhog2k.github.io/helm-charts/ | redis | 0.6.12 |
 
 ## Values
@@ -43,8 +43,8 @@ Watches deployments, daemonsets, and statefulsets for image updates and will aut
 | podAnnotations | object | `{}` |  |
 | podSecurityContext.fsGroup | int | `1001` |  |
 | podSecurityContext.seccompProfile.type | string | `"RuntimeDefault"` |  |
-| psaPatcher | object | `{"enabled":false}` | control the psa-restricted-patcher behavior, disabled by default, for more information see: https://artifacthub.io/packages/helm/psa-restricted-patcher/psa-restricted-patcher |
-| psaPatcher.enabled | bool | `false` | enable the psa patcher |
+| psa-patcher | object | `{"enabled":false}` | control the psa-restricted-patcher behavior, disabled by default, for more information see: https://artifacthub.io/packages/helm/psa-restricted-patcher/psa-restricted-patcher |
+| psa-patcher.enabled | bool | `false` | enable the psa patcher |
 | rbac.create | string | `"truewq"` |  |
 | redis.image.pullPolicy | string | `"Always"` |  |
 | redis.image.registry | string | `"ghcr.io"` |  |

--- a/charts/patchwork/values.yaml
+++ b/charts/patchwork/values.yaml
@@ -94,6 +94,6 @@ redis:
     tag: main
     pullPolicy: Always
 # -- control the psa-restricted-patcher behavior, disabled by default, for more information see: https://artifacthub.io/packages/helm/psa-restricted-patcher/psa-restricted-patcher
-psaPatcher:
+psa-patcher:
   # -- enable the psa patcher
   enabled: false


### PR DESCRIPTION
To avoid naming issues that don't align with RFC 1123, change the psaPatcher alias to psa-patcher